### PR TITLE
Update Vibrato to 0.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "thirdparty/mecab"]
 	path = thirdparty/mecab
 	url = https://github.com/taku910/mecab.git
-[submodule "thirdparty/vibrato"]
-	path = thirdparty/vibrato
-	url = https://github.com/daac-tools/vibrato.git

--- a/bench/vibrato-bench/Cargo.toml
+++ b/bench/vibrato-bench/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vibrato = { path = "../../thirdparty/vibrato/vibrato", default-features = false, features = ["unchecked"] }
+vibrato = { path = "../../thirdparty/vibrato/vibrato" }
 clap = { version = "~3.2.1", features = ["derive"] }  # MIT or Apache-2.0
 
 [profile.release.build-override]

--- a/bench/vibrato-bench/Cargo.toml
+++ b/bench/vibrato-bench/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vibrato = { path = "../../thirdparty/vibrato/vibrato" }
+vibrato = "=0.3.1"
 clap = { version = "~3.2.1", features = ["derive"] }  # MIT or Apache-2.0
 
 [profile.release.build-override]

--- a/bench/vibrato-bench/src/main.rs
+++ b/bench/vibrato-bench/src/main.rs
@@ -21,7 +21,8 @@ fn main() {
     let reader =
         BufReader::new(File::open(format!("{rootdir}/resources_{dictname}/system.dic")).unwrap());
     let dict = unsafe { Dictionary::read_unchecked(reader).unwrap() };
-    let mut tokenizer = Tokenizer::new(&dict);
+    let tokenizer = Tokenizer::new(dict);
+    let mut worker = tokenizer.new_worker();
 
     let lines: Vec<_> = std::io::stdin()
         .lock()
@@ -32,8 +33,9 @@ fn main() {
 
     let start = std::time::Instant::now();
     for line in &lines {
-        let tokens = tokenizer.tokenize(line).unwrap();
-        n_words += tokens.len();
+        worker.reset_sentence(line);
+        worker.tokenize();
+        n_words += worker.num_tokens();
     }
     let duration = start.elapsed();
 

--- a/bench/vibrato-bench/src/main.rs
+++ b/bench/vibrato-bench/src/main.rs
@@ -18,8 +18,7 @@ fn main() {
     let rootdir = env!("CARGO_MANIFEST_DIR");
     let dictname = args.dictname;
 
-    let reader =
-        BufReader::new(File::open(format!("{rootdir}/resources_{dictname}/system.dic")).unwrap());
+    let reader = BufReader::new(File::open(format!("{rootdir}/{dictname}/system.dic")).unwrap());
     let dict = unsafe { Dictionary::read_unchecked(reader).unwrap() };
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();

--- a/download_resources.sh
+++ b/download_resources.sh
@@ -26,8 +26,8 @@ popd
 
 pushd "./thirdparty/vibrato"
 ./scripts/prepare_ipadic-mecab-2_7_0.sh
-./scripts/prepare_unidic-cwj-3_1_0.sh
+./scripts/prepare_unidic-cwj-3_1_1.sh
 popd
 
 mv "./thirdparty/vibrato/resources_ipadic-mecab-2_7_0" "./bench/vibrato-bench/"
-mv "./thirdparty/vibrato/resources_unidic-cwj-3_1_0" "./bench/vibrato-bench/"
+mv "./thirdparty/vibrato/resources_unidic-cwj-3_1_1" "./bench/vibrato-bench/"

--- a/download_resources.sh
+++ b/download_resources.sh
@@ -24,10 +24,9 @@ rm -rf "./sudachi-dictionary-20210802"
 unzip "./sudachi-dictionary-20210802-core.zip"
 popd
 
-pushd "./thirdparty/vibrato"
-./scripts/prepare_ipadic-mecab-2_7_0.sh
-./scripts/prepare_unidic-cwj-3_1_1.sh
+pushd "./bench/vibrato-bench"
+wget https://github.com/daac-tools/vibrato/releases/download/v0.3.1/ipadic-mecab-2_7_0.tar.gz
+tar -xzf ipadic-mecab-2_7_0.tar.gz
+wget https://github.com/daac-tools/vibrato/releases/download/v0.3.1/unidic-cwj-3_1_1.tar.gz
+tar -xzf unidic-cwj-3_1_1.tar.gz
 popd
-
-mv "./thirdparty/vibrato/resources_ipadic-mecab-2_7_0" "./bench/vibrato-bench/"
-mv "./thirdparty/vibrato/resources_unidic-cwj-3_1_1" "./bench/vibrato-bench/"

--- a/run_all.sh
+++ b/run_all.sh
@@ -35,5 +35,5 @@ do
 
     ./bench/vibrato-bench/target/release/vibrato-bench --dictname="ipadic-mecab-2_7_0" < $INPUT_DATA
 
-    ./bench/vibrato-bench/target/release/vibrato-bench --dictname="unidic-cwj-3_1_0" < $INPUT_DATA
+    ./bench/vibrato-bench/target/release/vibrato-bench --dictname="unidic-cwj-3_1_1" < $INPUT_DATA
 done

--- a/stats.py
+++ b/stats.py
@@ -19,7 +19,7 @@ RE_DICT = [
     ('sudachi.rs', re.compile(r'Elapsed-sudachi.rs: ([0-9\.]+) \[sec\]')),
     ('rust-tinysegmenter', re.compile(r'Elapsed-rust-tinysegmenter: ([0-9\.]+) \[sec\]')),
     ('vibrato-ipadic-mecab-2_7_0', re.compile(r'Elapsed-vibrato-ipadic-mecab-2_7_0: ([0-9\.]+) \[sec\]')),
-    ('vibrato-unidic-cwj-3_1_0', re.compile(r'Elapsed-vibrato-unidic-cwj-3_1_0: ([0-9\.]+) \[sec\]')),
+    ('vibrato-unidic-cwj-3_1_1', re.compile(r'Elapsed-vibrato-unidic-cwj-3_1_1: ([0-9\.]+) \[sec\]')),
 ]
 
 


### PR DESCRIPTION
This PR updates the version of Vibrato to v0.3.1 and removes the submodule.